### PR TITLE
feat: circuit breaker for shipping-service and favourite-service routes

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,8 @@ spring:
         uri: lb://SHIPPING-SERVICE
         predicates:
         - Path=/shipping-service/**
+        filters:
+        - CircuitBreaker=shippingServiceCircuitBreaker
       - id: USER-SERVICE
         uri: lb://USER-SERVICE
         predicates:
@@ -56,6 +58,8 @@ spring:
         uri: lb://FAVOURITE-SERVICE
         predicates:
         - Path=/favourite-service/**
+        filters:
+        - CircuitBreaker=favouriteServiceCircuitBreaker
       - id: PROXY-CLIENT
         uri: lb://PROXY-CLIENT
         predicates:
@@ -73,6 +77,22 @@ resilience4j:
         permitted-number-of-calls-in-half-open-state: 3
         sliding-window-size: 10
         wait-duration-in-open-state: 5s
+        sliding-window-type: COUNT_BASED
+      shippingServiceCircuitBreaker:
+        register-health-indicator: true
+        automatic-transition-from-open-to-half-open-enabled: true
+        failure-rate-threshold: 50
+        minimum-number-of-calls: 3
+        sliding-window-size: 10
+        wait-duration-in-open-state: 10s
+        sliding-window-type: COUNT_BASED
+      favouriteServiceCircuitBreaker:
+        register-health-indicator: true
+        automatic-transition-from-open-to-half-open-enabled: true
+        failure-rate-threshold: 50
+        minimum-number-of-calls: 3
+        sliding-window-size: 10
+        wait-duration-in-open-state: 10s
         sliding-window-type: COUNT_BASED
 
 management:


### PR DESCRIPTION
This pull request adds circuit breaker functionality to the `SHIPPING-SERVICE` and `FAVOURITE-SERVICE` routes in the API Gateway configuration. It also defines custom circuit breaker settings for both services using Resilience4j. These changes improve the system's resilience by preventing cascading failures when these downstream services are unavailable or experiencing issues.

**Gateway configuration updates:**

* Added the `CircuitBreaker` filter to the `SHIPPING-SERVICE` and `FAVOURITE-SERVICE` routes in `application.yml`, enabling circuit breaker protection for these services. [[1]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR51-R52) [[2]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR61-R62)

**Resilience4j circuit breaker settings:**

* Defined custom circuit breaker configurations for `shippingServiceCircuitBreaker` and `favouriteServiceCircuitBreaker`, including health indicators, automatic state transitions, failure rate thresholds, minimum call requirements, sliding window size, and wait duration in the open state.