### PR TITLE
feat: add circuit breaker

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,6 +48,8 @@ spring:
         uri: lb://SHIPPING-SERVICE
         predicates:
         - Path=/shipping-service/**
+        filters:
+        - CircuitBreaker=shippingServiceCircuitBreaker
       - id: USER-SERVICE
         uri: lb://USER-SERVICE
         predicates:
@@ -56,6 +58,8 @@ spring:
         uri: lb://FAVOURITE-SERVICE
         predicates:
         - Path=/favourite-service/**
+        filters:
+        - CircuitBreaker=favouriteServiceCircuitBreaker
       - id: PROXY-CLIENT
         uri: lb://PROXY-CLIENT
         predicates:
@@ -73,6 +77,22 @@ resilience4j:
         permitted-number-of-calls-in-half-open-state: 3
         sliding-window-size: 10
         wait-duration-in-open-state: 5s
+        sliding-window-type: COUNT_BASED
+      shippingServiceCircuitBreaker:
+        register-health-indicator: true
+        automatic-transition-from-open-to-half-open-enabled: true
+        failure-rate-threshold: 50
+        minimum-number-of-calls: 3
+        sliding-window-size: 10
+        wait-duration-in-open-state: 10s
+        sliding-window-type: COUNT_BASED
+      favouriteServiceCircuitBreaker:
+        register-health-indicator: true
+        automatic-transition-from-open-to-half-open-enabled: true
+        failure-rate-threshold: 50
+        minimum-number-of-calls: 3
+        sliding-window-size: 10
+        wait-duration-in-open-state: 10s
         sliding-window-type: COUNT_BASED
 
 management:


### PR DESCRIPTION
This pull request enhances the application's resilience by introducing circuit breakers for the Shipping and Favourite services. Circuit breakers help prevent cascading failures by temporarily blocking calls to unstable services and allowing them to recover. The configuration is updated to define these circuit breakers and apply them to the relevant service routes.

Resilience improvements:

* Added circuit breaker filters to the `SHIPPING-SERVICE` and `FAVOURITE-SERVICE` routes in `application.yml` to enable resilience for these services. [[1]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR51-R52) [[2]](diffhunk://#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825dR61-R62)
* Defined new circuit breaker configurations (`shippingServiceCircuitBreaker` and `favouriteServiceCircuitBreaker`) under the `resilience4j` section with health indicators, automatic state transitions, and custom thresholds for failure rate and window size.